### PR TITLE
Remove pip --use-mirrors flag per its 7.0 deprecation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 before_install:
  - sudo apt-get update && sudo apt-get install -qq graphviz
 # command to install dependencies
-install: "pip install -q -r requirements.txt --use-mirrors"
+install: "pip install -q -r requirements.txt"
 # command to run tests
 script: sphinx-build -nW -b html -d _build/doctrees . _build/html
 # Flags used here, not in `make html`:


### PR DESCRIPTION
`--use-mirrors` [was deprecated](https://pip.pypa.io/en/stable/news/) with pip 7.0.0. It appears that Travis only recently started using a higher version (8.x) by default.

As [originally documented](https://pip.readthedocs.io/en/1.3.1/usage.html), `--use-mirrors` would search the PyPI mirrors if the main index was unavailable. I cannot find an official-looking discussion on the flag's removal, but I'm willing to risk losing this behavior due to the infrequency of these builds.