### PR TITLE
Changing to Markdown for articles instead of RST

### DIFF
--- a/actionables.md
+++ b/actionables.md
@@ -1,0 +1,73 @@
+Actionables
+===========
+
+Steps to Fighting Burnout
+-------------------------
+
+The general consensus seems to be that there are three steps in fighting
+against burnout:
+
+### 1. Determine if it's self-inflicted.
+
+If you can take some time off, be removed from on-call for a bit, or
+allow that next task to wait until you become yourself again, *do it*.
+Get some sleep and figure out what it will take to remove the strain.
+
+The objective is to maintain a healthy work-life balance. **Stop being a
+hero.** There is no benefit if the toll is so great that your personal
+life and relationships suffer.
+
+Make sure when you aren't in the office you spend some time doing
+something completely unrelated to your profession. We are all passionate
+about what we do, but if your hobby happens to be the same as your job,
+you may experience burnout much faster.
+
+### 2. Determine if it's an external pressure.
+
+-   Management says they need that new feature *now*.
+-   You're not allowed to fix the technical debt and apply band-aids
+    instead.
+-   You're constantly fighting fires.
+-   The only reason everything is working is because you put in too many
+    hours a week.
+
+If these sorts of situations sound familiar and you're burning out, it's
+time for the external factors to change.
+
+#### Find out what is causing the problem.
+
+Burnout can be caused by mindless repetition and interruptions. Or it
+can be middle-management setting unrealistic deadlines. Document the
+causes, then find ways to alleviate them.
+
+#### Communicate the burnout to people who can help.
+
+Sometimes all it takes is explaining the problem and talking it out with
+management and coworkers. Middle-management should exist to help
+specifically with these kinds of problems.
+
+#### Say "no" to unreasonable requests.
+
+Say "no" if a request is unreasonable, but try to provide feedback in
+order to prevent the pattern from continuing.
+
+Don't allow yourself to be talked down when it comes to time estimates.
+Instead, learn [Defense Against the Dark Art of Estimation Bargaining]
+
+#### "Yes, and..."
+
+If "no" doesn't work, try using the [Yes, and... technique] in order to
+emphasize your willingness to work with the requester but also take the
+opportunity to establish some boundaries and tradeoffs.
+
+For example:
+
+-   "Yes, we'll make sure Feature X is our top priority, and to
+    accommodate the new timeline we can put Features Y and Z on hold
+    until the next release."
+-   "Yes, we can plan on adding Project X to our responsibilities, and
+    we can take some time to plan the hiring we'll have to do in order
+    to meet that goal."
+
+  [Defense Against the Dark Art of Estimation Bargaining]: http://www.liquidplanner.com/blog/defense-dark-art-estimation-bargaining
+  [Yes, and... technique]: http://www.huffingtonpost.com/liz-orsquo/cant-say-no-say-yes-instead_b_4583052.html

--- a/conf.py
+++ b/conf.py
@@ -34,10 +34,16 @@ extensions = []
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
+from recommonmark.parser import CommonMarkParser
+
+source_parsers = {
+    '.md': CommonMarkParser,
+}
+
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
-# source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ['.rst', '.md']
+
 
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'

--- a/conf.py
+++ b/conf.py
@@ -80,7 +80,7 @@ language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
+exclude_patterns = ['_build', 'README.md', '.direnv']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/contribute.md
+++ b/contribute.md
@@ -1,0 +1,77 @@
+Contribute
+==========
+
+We value your ideas! If you'd like to help improve Burnout.io, do
+whatever works best for you:
+
+-   Open an [issue]
+-   [Fork] the project and submit a PR
+-   Send an [email]
+-   Reach out on [twitter]
+
+Info for Contributing to Burnout.io
+-----------------------------------
+
+-   This project is written in [reStructuredText]
+-   Hosted by [Read the Docs]
+-   Tested by rendering in [Sphinx] on [Travis CI]
+
+If you are looking to add content, fix formatting, syntax, typos or
+other wonderful things, please follow this process:
+
+-   Install Sphinx: `easy_install Sphinx sphinx_rtd_theme` or
+    `pip install -r requirements.txt`
+-   Fork the repository to your own account
+-   Check out a branch to make your changes on:
+    `git checkout --branch <my_topic>`
+-   Execute `make html` to build the docs in to `_build/`
+-   Make your changes
+-   Execute `make html` again and verify your changes don't cause any
+    warnings/errors
+-   Commit with a descriptive message, and submit a pull request from
+    your branch to `master`
+-   We'll review the change, and either merge it or provide some
+    feedback. Community review is also encouraged.
+
+A quick note if you're adding a new heading:
+
+Sphinx will error out if your title text is longer than the title
+underline. For example:
+`/projects/burnout.io/resources.rst:12: WARNING: Title underline too short.`
+
+And when you look at the title, you see:
+
+    This title is quite long...
+    -----
+
+Which will cause the error. Corrected, the tite would be more like:
+
+    This title is quite long...
+    -----------------------------------
+
+Which will correct the issue. For any other issues you run into, hop
+into the Gitter channel and one of us will help out.
+
+[![Gitter Channel]]
+
+Current Build Status
+--------------------
+
+[![Documentation Status]]
+
+[![Travis Build Status]]
+
+  [issue]: https://github.com/reignite/burnout.io/issues/new
+  [Fork]: https://github.com/reignite/burnout.io/fork
+  [email]: mailto:bemosior+burnoutio@gmail.com
+  [twitter]: https://twitter.com/BenjaminMosior
+  [reStructuredText]: http://docutils.sourceforge.net/docs/user/rst/quickstart.html
+  [Read the Docs]: http://readthedocs.org/
+  [Sphinx]: http://sphinx-doc.org/
+  [Travis CI]: https://travis-ci.org
+  [Gitter Channel]: https://badges.gitter.im/Join%20Chat.svg
+  [![Gitter Channel]]: https://gitter.im/reignite/burnout.io
+  [Documentation Status]: https://readthedocs.org/projects/burnoutio/badge/?version=latest
+  [![Documentation Status]]: http://burnoutio.readthedocs.org/en/latest/?badge=latest
+  [Travis Build Status]: https://travis-ci.org/reignite/burnout.io.svg
+  [![Travis Build Status]]: https://travis-ci.org/reignite/burnout.io

--- a/furtherReading.md
+++ b/furtherReading.md
@@ -1,0 +1,58 @@
+Further Reading
+===============
+
+We've all faced burnout--here are some quotes from around the community.
+
+> "Horde statistics: 1 in 3 thought about quitting because of stress,
+> 75% are not engaged with their work, over 1 million absent per day..."
+> - [Avoiding Burnout: The Zombie Survival Guide] - David Manners
+>
+> "EDD \[Experience Driven Development\] - some basic information around
+> the topic mental health/illness in IT" - [EDD (Experience Driven
+> Development)] - Michael Scholl
+>
+> "Mental disorders are the largest contributor to disease burden in
+> North America, but the developer community and those who employ us are
+> afraid to face the problem head-on. In this talk, we'll examine the
+> state of mental health awareness in the developer workplace, why most
+> developers feel it isn't safe to talk about mental health, and what we
+> can do to change the culture and save lives." - [Stronger Than Fear:
+> Mental Health in the Developer Community] - Ed Finkler
+>
+> "While critically important as a tool to help, these solutions also
+> don’t directly address the path to burnout. They don’t tackle the
+> systemic problems within both startups and larger organizations that
+> lead to burnout. They gloss over the patterned behaviors of
+> sociopathic (or even merely incompetent) managers." - [Dodging
+> Burnout, 4 Hours at a Time] - J. Paul Reed
+>
+> "You didn’t mean to end up here. You didn’t even see it coming... It
+> all started with a chance to earn a living doing something you loved.
+> Your dream job. Creating things instead of rotting in a cubicle. You
+> weren’t just going to make a living — you were going to leave your
+> mark on the world." - [The Cult of Work You Never Meant to Join] -
+> Jason Lengstorf
+>
+> "If... you work for someone for money, you're just a factor of
+> production... You're trading your time, your skills, your talent for
+> that money... Every time you stay after work late, you're giving away
+> that time away for free." - [Go the F\*\*\* Home] - Pam Selle
+>
+> "It is true that I would insist that I could handle it, and I guess I
+> did, but don’t organizations have a responsibility to their employees
+> to stop them from harming themselves in the name of the job?" - [A
+> Year of Fire and Fog] - Alex Nobert
+>
+> "Sometimes it's the feelings of burnout... things we struggle with in
+> our jobs, particularly with some of the ill-defined tasks that we get
+> as software developers, and some of the high-stress workplaces that we
+> put ourselves in that demand constant contact and constant
+> availability." - \`Node
+
+  [Avoiding Burnout: The Zombie Survival Guide]: https://github.com/dmanners/avoiding-burnout/blob/master/Avoiding%20Burnout.pdf
+  [EDD (Experience Driven Development)]: https://speakerdeck.com/mischosch/developers-mental-health
+  [Stronger Than Fear: Mental Health in the Developer Community]: https://github.com/cascadiajs/2015.cascadiajs.com/issues/228
+  [Dodging Burnout, 4 Hours at a Time]: https://medium.com/@jpaulreed/dodging-burnout-4-hours-at-a-time-965f1921e6a2
+  [The Cult of Work You Never Meant to Join]: http://lengstorf.com/overkill-cult/?utm_source=burnout-io
+  [Go the F\*\*\* Home]: https://www.youtube.com/watch?v=YBoS-svKdgs
+  [A Year of Fire and Fog]: https://medium.com/@nobert/a-year-of-fire-and-fog-2c68f90c74e4

--- a/index.rst
+++ b/index.rst
@@ -30,9 +30,8 @@ Table of Contents
 .. toctree::
    :maxdepth: 2
 
-   actionables.rst
-   moreIdeas.rst
-   resources.rst
-   furtherReading.rst
-   contribute.rst
-
+   actionables.md
+   moreIdeas.md
+   resources.md
+   furtherReading.md
+   contribute.md

--- a/moreIdeas.md
+++ b/moreIdeas.md
@@ -1,0 +1,63 @@
+More Ideas
+==========
+
+More ideas to help recover from burnout
+---------------------------------------
+
+### Acknowledge your feelings.
+
+How are you feeling? It is valid. Share your feelings with your support
+network. This helps build *resilience*. Recognize your state in the
+*exhaustion funnel* and how that will impact your decisions.
+
+### Build your identity.
+
+You are more than your job. You are more than the contributions that you
+make to open source projects. Who are you?
+
+Understanding who you are and what you value can help keep you afloat
+when traumatic events like a company layoff occur. If your identity is
+derived from your job, losing your job can leave you feeling like you
+have no meaning or value. Companies fail all the time. More startups
+close than make it to a finish line. Avoid tying your mental health to
+the success of something outside of your control.
+
+### Fuel up
+
+Know yourself. Know what energizes or calms you. Whether it's reading,
+non-technical activity time, being off in a forest with the greenery, or
+something else. Monitor your "fuel" levels and recognize when you need
+to take a break. Talk to your Support network and ask them to give you
+external signals.
+
+#### A few ways to fuel up at home & work
+
+##### Take micro-breaks and play
+
+It can help to take some time for micro-breaks and play. It sounds a bit
+unconventional to say "play," but it can be a helpful step in breaking
+the burnout cycle. Micro-breaks can be helpful by taking the step back
+from the work and getting your mind off of whatever is causing the
+burnout. Micro-breaks come in a variety of forms:
+
+-   Getting up from the desk/cube and taking 15 minutes to walk around
+    the office, get outside, and get some air/sunshine
+-   Grab a colleague and talk about anything other than the task(s) at
+    hand. This will take practice, but can be beneficial in ways other
+    than taking a break--it may open doors to move to a position that
+    can be less stressful
+-   Get a pair of baseball gloves, or a frisbee, go out into the parking
+    lot (if available, if not, a green space), and toss the ball/frisbee
+    around for a few minutes.
+
+###### A note on micro-breaks:
+
+If it's not possible to take these sorts of breaks, do your best to not
+take work home, if at all possible. The expectation that you have to
+work all the time, even at home, isn't realistic and can create feelings
+of guilt when not engaged in work. If this is the case for you, enlist
+the help of someone in your support community--a significant other,
+family member, peer or friend to help keep you accountable to not spend
+all of your time working and send you signals (or blatantly tell you)
+when work has become an unhealthy priority. When possible, take the time
+at home to enjoy your home, and play

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 Sphinx==1.6.6
 sphinx-rtd-theme==0.2.4
+
+-e git+https://github.com/rtfd/recommonmark.git#egg=recommonmark

--- a/resources.md
+++ b/resources.md
@@ -1,0 +1,65 @@
+Resources
+=========
+
+List of Resources
+-----------------
+
+We've all struggled with being burnt out and it's not easy. That's why
+we've compiled a list of resources here that have helped us, as well as
+other in the community, in the fight against burnout.
+
+### Talking to a Real Person
+
+There's always someone availalbe in our gitter channel. If you'd like to
+talk with someone who's been through the cycle of burnout, reach out!
+We'd love to help in any way we can:
+
+[![Gitter Channel]]
+
+You can also find others you can talk to who have gone through similar
+experiences. There are people at conferences, on [Reddit] , on [Twitter]
+, and maybe even at your workplace who know what you are going through
+and can help.
+
+### Online Resources
+
+-   [Critical Mental Health Resources For College Students]
+-   [If Me]
+-   [Mental Health First Aid]
+-   [HelpGuide.org]
+-   [DevPressed]
+-   [National Alliance on Mental Illness]
+-   [NAMI Local Chapters]
+-   [Mental Health America]
+-   [National Institute of Mental Health]
+-   [BlueHackers]
+-   [Geek Mental Help Week]
+-   [Mental Illness Happy Hour]
+-   [Mind Mental Health Charity]
+-   [LIS Mental Health Doc]
+
+### Further Reading
+
+There are a number of courageous people in the community talking about
+burnout, their experiences with it and how they've made progress. Read
+more about what they have to say at the [Further reading] page.
+
+  [Gitter Channel]: https://badges.gitter.im/Join%20Chat.svg
+  [![Gitter Channel]]: https://gitter.im/reignite/burnout.io
+  [Reddit]: http://www.reddit.com/r/sysadmin/search?q=burnout&sort=top&restrict_sr=on
+  [Twitter]: https://twitter.com/search?q=burnout&src=typd
+  [Critical Mental Health Resources For College Students]: http://www.onlinecolleges.net/for-students/mental-health-resources/
+  [If Me]: http://www.if-me.org/
+  [Mental Health First Aid]: http://www.mentalhealthfirstaid.org/
+  [HelpGuide.org]: http://helpguide.org/
+  [DevPressed]: http://www.devpressed.com/
+  [National Alliance on Mental Illness]: http://nami.org/
+  [NAMI Local Chapters]: http://bit.ly/namilocal
+  [Mental Health America]: http://www.mentalhealthamerica.net/
+  [National Institute of Mental Health]: http://www.nimh.nih.gov
+  [BlueHackers]: http://BlueHackers.org
+  [Geek Mental Help Week]: http://geekmentalhelp.com/
+  [Mental Illness Happy Hour]: http://mentalpod.com/
+  [Mind Mental Health Charity]: http://www.mind.org.uk/
+  [LIS Mental Health Doc]: http://tiny.cc/LISmentalhealth
+  [Further reading]: furtherReading.html


### PR DESCRIPTION
This should fix #56 . My gut hunch is that for most folks, Markdown is much more familiar/easier to write in, hence moving things over. We'll probably have to start adopting some sort of styleguide down the road, but this gets things moving in that direction.